### PR TITLE
fixed a critical naming error

### DIFF
--- a/backend/AI_services/ai_services/interfaces.py
+++ b/backend/AI_services/ai_services/interfaces.py
@@ -53,7 +53,7 @@ class DeviceAwareModel(ABC):
         ...
 
 
-class FactCheckerInterface(BaseModel):
+class FactCheckerInterface(DeviceAwareModel):
     """
     Defines the interface for an AI-based fact-checking service.
     """


### PR DESCRIPTION
This pull request updates the `FactCheckerInterface` class to inherit from `DeviceAwareModel` instead of `BaseModel`, aligning it with the device-aware architecture for AI services.

Key change:

* [`backend/AI_services/ai_services/interfaces.py`](diffhunk://#diff-a00bcd07c89d343808967098ff93ae4ffbff4224702977057b410c1b07a9e63cL56-R56): Updated the `FactCheckerInterface` class to inherit from `DeviceAwareModel`, enabling it to support device-specific operations such as moving to "cpu" or "cuda".